### PR TITLE
allow singlenamespace and cluster namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -39,6 +40,11 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+	//env variable that control behaviour of operator
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+    // which specifies the Namespace to watch.
+    // An empty value means the operator is running with cluster scope.
+	watchNamespaceEnvVar = "WATCH_NAMESPACE"
 )
 
 func init() {
@@ -65,6 +71,14 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	watchNamespace, err := getWatchNamespace()
+	if err != nil {
+		setupLog.Error(err, "unable to get WatchNamespace, " +
+		"the manager will watch and manage resources in all namespaces")
+	}else{
+		setupLog.Info("the manager will watch crd in the namespace: "+watchNamespace)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -72,6 +86,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "49dd0669.onyxia.sh",
+		Namespace: watchNamespace,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -112,4 +127,13 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func getWatchNamespace() (string, error) {
+
+    ns, found := os.LookupEnv(watchNamespaceEnvVar)
+    if !found {
+        return "", fmt.Errorf("%s must be set", watchNamespaceEnvVar)
+    }
+    return ns, nil
 }


### PR DESCRIPTION
this allow set/export WATCH_NAMESPACE=testcrd && go run main.go to watch only one namespace if not specifie standard cluster wide.

The value of the namespace should be specified in helm chart probably